### PR TITLE
chore: Remove the release jobs

### DIFF
--- a/.github/workflows/jicmp-build.yaml
+++ b/.github/workflows/jicmp-build.yaml
@@ -36,22 +36,9 @@ jobs:
         with:
           name: jicmp-debian
           path: debian/artifacts/*
-
-  ## Publish a release triggered by a git tag push
-  release:
-    needs:
-      - build
-    # Only publish release artifacts on pushing a Git tag with a version number starting with v*
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    container:
-      image: quay.io/bluebird/java-builder:0.0.3.jdk-8
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: jicmp-debian
-          path: debian/artifacts
       - name: Publish Debian packages to Cloudsmith
+        # Only publish release artifacts on pushing a Git tag with a version number starting with v*
+        if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: |
           export CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }}


### PR DESCRIPTION
Deduplicate the release job and just have the push to cloudsmith step running when tags are pushed.